### PR TITLE
feat: better flagtext

### DIFF
--- a/bytefield.typ
+++ b/bytefield.typ
@@ -80,7 +80,7 @@
 #let padding(..args) = bitbox(none, ..args)
 
 // Rotating text for flags
-#let flagtext(text) = align(end,pad(-3pt,rotate(270deg,text)))
+#let flagtext(text) = align(center,rotate(270deg,text))
 
 // Common network protocols
 #let ipv4 = bytefield(


### PR DESCRIPTION
This changes the flagtext implementation from a constant pt offset to something more consistent with varying text and font size. In particular I have an example where with the current implementation I end up with:
![image](https://github.com/jomaway/typst-bytefield/assets/33270164/f2de8f6d-370a-4f81-afea-b195b63b949d)
while the new implementation produces:
![image](https://github.com/jomaway/typst-bytefield/assets/33270164/5622e4ff-37d2-4515-93bd-e10b3dae6f4d)
with no (to me) visible change to your example document.