### PR TITLE
[feat] Add "smart" bitheaders

### DIFF
--- a/bytefield.typ
+++ b/bytefield.typ
@@ -25,6 +25,8 @@
   let cells = ()
 
   // calculate cells
+  let current_offset = 0;
+  let computed_offsets = ();
   for (idx, field) in fields.pos().enumerate() {
     let (size, content, fill, ..) = field;
     let remaining_cols = bits - col_count;
@@ -34,6 +36,10 @@
       size = remaining_cols
       content = content + sym.star
     }
+
+    computed_offsets.push(current_offset);
+    current_offset += size;
+    
     if size > bits and remaining_cols == bits and calc.rem(size, bits) == 0 {
       content = content + " (" + str(size) + " Bit)"
       cells.push(bfcell(int(bits),fill:fill, height: rowheight * size/bits)[#content])
@@ -48,6 +54,8 @@
     }
   
   }
+  
+  computed_offsets.push(bits - 1);
 
 
   bitheader = if bitheader == auto { 
@@ -56,12 +64,14 @@
       } else { none })
   } else if bitheader == "all" {
     range(bits).map(i => text(9pt)[#i])
+  } else if bitheader == "smart" {
+    range(bits).map(i => if i in computed_offsets { text(9pt)[#i] } else {none})
   } else if bitheader != none {
-    assert(type(bitheader) == array, message: "header must be an array, none or 'all' ")
+    assert(type(bitheader) == array, message: "header must be an array, none, 'all' or 'smart'")
     range(bits).map(i => if i in bitheader { text(9pt)[#i] } else {none})
   }
 
-  if(msb_first == true) {
+  if msb_first == true {
     bitheader = bitheader.rev()
   }
 

--- a/bytefield.typ
+++ b/bytefield.typ
@@ -57,18 +57,22 @@
   
   computed_offsets.push(bits - 1);
 
-
+  let bitheader_font_size = 9pt;
   bitheader = if bitheader == auto { 
-    range(bits).map(i => if calc.rem(i,8) == 0 or i == (bits - 1) { 
-      text(9pt)[#i]
-      } else { none })
+    range(bits).map(i =>
+      if calc.rem(i,8) == 0 or i == (bits - 1) { text(bitheader_font_size)[#i] } 
+      else { none })
   } else if bitheader == "all" {
     range(bits).map(i => text(9pt)[#i])
   } else if bitheader == "smart" {
-    range(bits).map(i => if i in computed_offsets { text(9pt)[#i] } else {none})
+    if msb_first == true {
+      computed_offsets = computed_offsets.map(i => bits - i - 1);
+    }
+
+    range(bits).map(i => if i in computed_offsets { text(bitheader_font_size)[#i] } else {none})
   } else if bitheader != none {
     assert(type(bitheader) == array, message: "header must be an array, none, 'all' or 'smart'")
-    range(bits).map(i => if i in bitheader { text(9pt)[#i] } else {none})
+    range(bits).map(i => if i in bitheader { text(bitheader_font_size)[#i] } else {none})
   }
 
   if msb_first == true {

--- a/example.typ
+++ b/example.typ
@@ -31,6 +31,20 @@ Show all bit headers with `bitheader: "all"`
     ..range(16).map(i => bit[#flagtext[B#i]]).rev(),
 )
 
+== Smart bit header
+
+Show start bit of each bitbox with `bitheader: "smart"`.
+
+#bytefield(
+  bits: 32,
+  // same as bitheader: (0,8,13,18,23,31),
+  bitheader: "smart",
+  bits(8)[opcode],
+  bits(5)[rd],
+  bits(5)[rs1],
+  bits(5)[rs2],
+  padding()[]
+)
 
 == Custom bit header
 

--- a/example.typ
+++ b/example.typ
@@ -46,6 +46,20 @@ Show start bit of each bitbox with `bitheader: "smart"`.
   padding()[]
 )
 
+And with `msb_first: true`:
+
+#bytefield(
+  bits: 32,
+  msb_first: true,
+  // same as bitheader: (0,8,13,18,23,31),
+  bitheader: "smart",
+  bits(8)[opcode],
+  bits(5)[rd],
+  bits(5)[rs1],
+  bits(5)[rs2],
+  padding()[]
+)
+
 == Custom bit header
 
 #bytefield(


### PR DESCRIPTION
This pull request implements the `"smart"` mode for bitheaders, which show bit offset of at each bitbox (see the figure below).

Maybe the `auto` mode should be replaced by `"smart"` and allowing bitheader taking an integer, so all bits at multiple offset of this integer are displayed?

The code:
```typ
#bytefield(
  bits: 32,
  // same as bitheader: (0,8,13,18,23,31),
  bitheader: "smart",
  bits(8)[opcode],
  bits(5)[rd],
  bits(5)[rs1],
  bits(5)[rs2],
  padding()[]
)
```
Will generate:

![image](https://github.com/jomaway/typst-bytefield/assets/42495291/2fe9999e-7003-4eb3-bcb4-d23286c33b6b)

Tell me if I need to modify anything, I barely know how Typst works.