### PR TITLE
Stroke cutomization support

### DIFF
--- a/docs/docs.typ
+++ b/docs/docs.typ
@@ -268,11 +268,12 @@ You can set some global default values which affect all `bytefields` by using a 
 *Example:*
 ```typst
 #show: bf-config.with(
-  field_font_size: 15.5pt,
-  note_font_size: 6pt,
-  header_font_size: 12pt,
-  header_background: luma(200),
-  header_border: luma(80),
+  field-font-size: 15.5pt,
+  note-font-size: 6pt,
+  header-font-size: 12pt,
+  header-background: luma(200),
+  header-border: luma(80),
+	stroke: .5pt + red
 )
 ```
 

--- a/lib/gen.typ
+++ b/lib/gen.typ
@@ -394,8 +394,6 @@
     let rows = if (meta.rows.main == auto) { get-default-row-height() } else { meta.rows.main }
     if (type(rows) == array) { rows = rows.map(r => if (r == auto) { get-default-row-height() } else { r } )}
 
-    let default-stroke = get-default-stoke()
-
     // somehow grid_header still needs to exists.
     let grid_header = if (meta.header != none) {
       grid(

--- a/lib/gen.typ
+++ b/lib/gen.typ
@@ -165,14 +165,15 @@
       let cell_size = calc.min(len, rem_space);
 
       // calc stroke
-      let _default_stroke = (1pt + black)
+      // this gets populated with the default stroke later, when the context is available
+      let _default_stroke = auto
       let _stroke = (
         top: _default_stroke,
         bottom: _default_stroke,
         rest: _default_stroke,
       )
 
-      if ((len - cell_size) > 0 and data_fields.last().field-index != field.field-index) {
+      if ((len - cell_size) > 0 and data_fields.last().field-index != field.field-index and not should_span) {
         _stroke.at("bottom") = field.data.format.fill
       }
       if (slice_idx > 0){
@@ -362,6 +363,16 @@
         ]
       }
     }
+    
+    let stroke = c.format.at("stroke", default: none)
+    // context available now, so changing to default stroke
+    if type(stroke) == dictionary {
+      for key in stroke.keys() {
+        if stroke.at(key) == auto {
+          stroke.at(key) = get-default-stoke()
+        }
+      }
+    }
 
     return grid.cell(
       x: c.position.x,
@@ -369,7 +380,7 @@
       colspan: c.span.cols,
       rowspan: c.span.rows,
       inset: c.format.at("inset", default: 0pt),
-      stroke: c.format.at("stroke", default: none),
+      stroke: stroke,
       fill: c.format.at("fill", default: none),
       align: c.format.at("align", default: center + horizon),
       body
@@ -382,6 +393,8 @@
   let table = context {
     let rows = if (meta.rows.main == auto) { get-default-row-height() } else { meta.rows.main }
     if (type(rows) == array) { rows = rows.map(r => if (r == auto) { get-default-row-height() } else { r } )}
+
+    let default-stroke = get-default-stoke()
 
     // somehow grid_header still needs to exists.
     let grid_header = if (meta.header != none) {

--- a/lib/states.typ
+++ b/lib/states.typ
@@ -5,6 +5,7 @@
 #let default-note-font-size = state("bf-note-font-size", auto);
 #let default-header-background = state("bf-header-bg", none);
 #let default-header-border = state("bf-header-border", none);
+#let default-stroke = state("bf-default-stroke", (1pt + black));
 
 // function to use with show rule
 #let bf-config(
@@ -14,6 +15,7 @@
   header-font-size: 9pt,
   header-background: none,
   header-border: none,
+  stroke: (1pt + black),
   content
   ) = {
   default-row-height.update(row-height);
@@ -22,6 +24,7 @@
   default-note-font-size.update(note-font-size)
   default-header-background.update(header-background)
   default-header-border.update(header-border)
+  default-stroke.update(stroke)
   content
 }
 
@@ -48,4 +51,8 @@
 
 #let get-default-header-border() = {
   default-header-border.get()
+}
+
+#let get-default-stoke() = {
+  default-stroke.get()
 }


### PR DESCRIPTION
Hello and thank you very much for this great library!

The stroke of the library was to tick for the design of my document that I wanted to create, so I added a configuration option for the default stroke thickness + color.

when adding the following code:

```typst
#show: bf-config.with(
  stroke: rgb(248,143,176) + 2pt
)
```
You get this result

![bitfield-demo](https://github.com/user-attachments/assets/497429b7-e901-490d-8a26-ff6d2e7efec8)

https://typst.app/project/wC0YjelYLfz0W67VZCnZx3

fixes #39